### PR TITLE
Clarified that external processing library is needed

### DIFF
--- a/examples/bar-print/bar-print.ino
+++ b/examples/bar-print/bar-print.ino
@@ -18,7 +18,9 @@ The sensor is set to Centroid mode and touch location and size
 printed to the serial port for each of the 5 different simultaneous
 touches.
 
-The accompanying Processing sketch, `TrillBarDisplay.pde`, listens for
+You can find our Processing library for visualising here:
+https://github.com/BelaPlatform/trill-processing-library/
+The accompanying Processing sketch, `TrillBar.pde`, listens for
 touch information on the Arduino serial port* and displays it in a
 render of a Trill Bar.
 

--- a/examples/flex-print-slider/flex-print-slider.ino
+++ b/examples/flex-print-slider/flex-print-slider.ino
@@ -23,6 +23,8 @@ touch location and size of touches on the default Flexible Bar sensor.
 Touchese will be printed to the serial port for each of the 5 different
 simultaneous touches.
 
+You can find our Processing library for visualising here:
+https://github.com/BelaPlatform/trill-processing-library/
 The accompanying Processing sketch, `TrillFlexSlider.pde`, listens for
 touch information on the Arduino serial port* and displays it in a
 render of a Trill Flex.

--- a/examples/square-print/square-print.ino
+++ b/examples/square-print/square-print.ino
@@ -17,9 +17,12 @@ sensor using the Trill Arduino library.
 The sensor is set to Centroid mode and 2D touch location and size
 printed to the serial port.
 
-The accompanying Processing sketch, `TrillSquareDisplay.pde`, listens for
+You can find our Processing library for visualising here:
+https://github.com/BelaPlatform/trill-processing-library/
+The accompanying Processing sketch, `TrillSquare.pde`, listens for
 touch information on the Arduino serial port and displays it in a
 render of a Trill Square.
+
 You may need to update the Processing port number (gPortNumber)
 to match that of your Arduino and set `verbose = false` below in order to
 make the serial data parseable by the Processing sketch.


### PR DESCRIPTION
The READMEs for the examples for TrillBar, TrillFlexSlider and TrillSquare referenced Processing sketches that were not in the example folder, but in an external library (https://github.com/BelaPlatform/trill-processing-library/). I added these references. Also made sure that the names matched in the READMEs and the external library.